### PR TITLE
feat: add support for fuzzy name matching in pydantic

### DIFF
--- a/src/fuzztype/__init__.py
+++ b/src/fuzztype/__init__.py
@@ -1,5 +1,6 @@
 from .entity import Entity, EntitySource
 from .fuzztype import FuzzType
+from .namestr import NameStr, CasedNameStr
 from .fuzzstr import FuzzStr
 from .findstr import FindStr
 
@@ -8,9 +9,11 @@ __version__ = "0.0.1"
 
 
 __all__ = (
+    "CasedNameStr",
     "Entity",
     "EntitySource",
     "FindStr",
     "FuzzStr",
     "FuzzType",
+    "NameStr",
 )

--- a/src/fuzztype/namestr.py
+++ b/src/fuzztype/namestr.py
@@ -1,0 +1,49 @@
+from typing import Iterable
+
+from pydantic_core import PydanticCustomError
+
+from . import Entity, FuzzType
+
+
+def NameStr(source: Iterable, case_sensitive: bool = False):
+    return FuzzType(lookup_function=NameLookup(source, case_sensitive))
+
+
+def CasedNameStr(source: Iterable):
+    return FuzzType(lookup_function=NameLookup(source, True))
+
+
+class NameLookup:
+    def __init__(self, source: Iterable, case_sensitive: bool):
+        self.prepped: bool = False
+        self.source: Iterable = source
+        self.case_sensitive: bool = case_sensitive
+        self.name_exact: dict[str, str] = {}
+        self.name_lower: dict[str, str] = {}
+
+    def __call__(self, key: str) -> str:
+        if not self.prepped:
+            self._prep_source()
+
+        name = self.name_exact.get(key)
+        if not self.case_sensitive and name is None:
+            name = self.name_lower.get(key.lower())
+
+        if name is None:
+            msg = "Key ({key}) not found."
+            raise PydanticCustomError("name_str_not_found", msg, dict(key=key))
+
+        return name
+
+    # private functions
+
+    def _prep_source(self):
+        if self.prepped:
+            return
+
+        self.prepped = True
+        for item in self.source:
+            entity = Entity.convert(item)
+            self.name_exact[entity.name] = entity.name
+            self.name_lower[entity.name.lower()] = entity.name
+

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -98,25 +98,25 @@ def test_loader_label_iterator(MyEntities):
                 "ctx": {
                     "key": "apple",
                     "nearest": "Eagle [60.0], canine => Dog [36.4], feline "
-                               "=> Cat [36.4]",
+                    "=> Cat [36.4]",
                 },
                 "input": "apple",
                 "loc": ("animal",),
                 "msg": "key (apple) not resolved (nearest: Eagle [60.0], "
-                       "canine => Dog [36.4], feline => Cat [36.4])",
+                "canine => Dog [36.4], feline => Cat [36.4])",
                 "type": "fuzz_str_not_resolved",
             },
             {
                 "ctx": {
                     "key": "dog",
                     "nearest": "malus domestica => Apple [22.2], fragaria => "
-                               "Strawberry [18.2], Apple [0.0]",
+                    "Strawberry [18.2], Apple [0.0]",
                 },
                 "input": "dog",
                 "loc": ("fruit",),
                 "msg": "key (dog) not resolved (nearest: malus domestica => "
-                       "Apple [22.2], fragaria => Strawberry [18.2], Apple ["
-                       "0.0])",
+                "Apple [22.2], fragaria => Strawberry [18.2], Apple ["
+                "0.0])",
                 "type": "fuzz_str_not_resolved",
             },
         ]

--- a/tests/test_namestr.py
+++ b/tests/test_namestr.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel, ValidationError
+
+from fuzztype import NameStr, CasedNameStr
+
+names = ["George Washington", "John Adams", "Thomas Jefferson"]
+President = NameStr(names)
+CasedPresident = CasedNameStr(names)
+
+
+def test_getitem():
+    assert President["Thomas Jefferson"] == "Thomas Jefferson"
+    assert President["THOMAS JEFFERSON"] == "Thomas Jefferson"
+
+    assert CasedPresident["Thomas Jefferson"] == "Thomas Jefferson"
+    try:
+        assert CasedPresident["THOMAS JEFFERSON"] == "Thomas Jefferson"
+        assert False, "Didn't raise KeyError!"
+    except KeyError:
+        pass
+
+
+def test_uncased_name_str():
+    class Example(BaseModel):
+        name: President
+
+    # exact match
+    assert Example(name="George Washington").name == "George Washington"
+
+    # case-insensitive match
+    assert Example(name="john ADAMS").name == "John Adams"
+
+
+def test_cased_name_str():
+    class Example(BaseModel):
+        name: CasedPresident
+
+    # exact match
+    assert Example(name="George Washington").name == "George Washington"
+
+    # case-insensitive match
+    try:
+        assert Example(name="john ADAMS").name == "John Adams"
+        assert False, "Didn't raise PydanticCustomError!"
+    except ValidationError:
+        pass
+


### PR DESCRIPTION
- Added `NameStr` and `CasedNameStr` classes to support fuzzy name matching in pydantic.
- `NameStr` performs case-insensitive matching and returns the exact match from the provided source.
- `CasedNameStr` performs case-sensitive matching and returns the exact match from the provided source.
- Added unit tests for `NameStr` and `CasedNameStr` classes.